### PR TITLE
Increased description size to 1000 characters

### DIFF
--- a/tables.sql
+++ b/tables.sql
@@ -11,7 +11,7 @@ CREATE TABLE `sc_bookmarks` (
   `bModified` datetime NOT NULL default '0000-00-00 00:00:00',
   `bTitle` varchar(255) NOT NULL default '',
   `bAddress` text NOT NULL,
-  `bDescription` varchar(255) default NULL,
+  `bDescription` varchar(1000) default NULL,
   `bHash` varchar(32) NOT NULL default '',
   PRIMARY KEY  (`bId`),
   KEY `sc_bookmarks_usd` (`uId`,`bStatus`,`bDatetime`),

--- a/templates/editbookmark.tpl.php
+++ b/templates/editbookmark.tpl.php
@@ -31,7 +31,7 @@ switch ($row['bStatus']) {
 </tr>
 <tr>
     <th align="left"><?php echo T_('Description'); ?></th>
-    <td><input type="text" name="description" size="75" maxlength="255" value="<?php echo filter($row['bDescription'], 'xml'); ?>" /></td>
+    <td><textarea name="description" cols="74" rows="5" maxlength="1000"><?php echo filter($row['bDescription'], 'xml'); ?></textarea></td>
     <td></td>
 </tr>
 <tr>


### PR DESCRIPTION
The default maximum description in Delicious was raised to 1000 characters instead of 255 several years ago. The current setting in Scuttle makes it impossible for users to import data from their Delicious account into Scuttle.

When the limit is increased, the old text-box becomes rather too small. This increases it (in line with what Delicious did when they made the change).

In this patch, tables.sql is updated, but existing installations will need to alter their database table my hand. In the absence of a system for migrations, this seems to be able the best we can do.

That said, this patch should not break directly. It will allow people to submit longer items which will then be rejected (or just cropped to 255 characters, I suppose) by MySQL. As a result, this patch, if accepted, would need to be moved into the release notes.
